### PR TITLE
clevis pin: fix poll bugs

### DIFF
--- a/src/clevis/common.c
+++ b/src/clevis/common.c
@@ -164,13 +164,14 @@ request(const json_t *cfg, TANG_MSG *req)
 
             memcpy(ofds, ifds, sizeof(struct pollfd) * naddr);
             r = poll(ofds, naddr, 1000);
-            for (int j = 0; j < r; j++) {
+            for (int j = 0; r > 0 && j < naddr; j++) {
                 TANG_MSG *rep = NULL;
                 pkt_t in = {};
 
-                if (ofds[j].revents & (POLLIN | POLLPRI) == 0)
+                if ((ofds[j].revents & (POLLIN | POLLPRI)) == 0)
                     continue;
 
+                r--;
                 in.size = recv(ofds[j].fd, &in.data, sizeof(in.data), 0);
                 if (in.size <= 0)
                     continue;


### PR DESCRIPTION
If the Tang server hostname resolves to multiple addresses but is
not accessible at the first address, the request procedure does not
read the correct file descriptor, due to a precedence error when
examining the revents member.

Furthermore, the return value of poll(2) is the number of file
descriptors with events, but iteration of the poll array is
constrained to j < r.  If one event occurred (r = 1), on the second
fd (j = 1), it cannot be reached.

This commit fixes these issues.
