### PR TITLE
askpassd: reload resolver info in main loop

### DIFF
--- a/src/clt/luks/askp/tang-luks-askpassd.c
+++ b/src/clt/luks/askp/tang-luks-askpassd.c
@@ -30,6 +30,7 @@
 #include <sys/stat.h>
 #include <errno.h>
 #include <error.h>
+#include <resolv.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -175,6 +176,7 @@ main(int argc, char *argv[])
         fds.all[i].events |= POLLRDHUP;
 
     for (int events; (events = poll(fds.all, ALLCNT, timeout)) >= 0; ) {
+        res_init();
         bool process = false;
 
         for (size_t i = 0; i < ALLCNT; i++) {


### PR DESCRIPTION
If DHCP receives resolver info and updates /etc/resolv.conf after
tang-luks-askpassd has started, tang-luks-askpassd continues in
ignorance and remains unable to resolve hostnames of Tang servers.

Call res_init() on each iteration of the main loop so that changes
to /etc/resolv.conf are picked up.
