### PR TITLE
Add autoreconf step to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This is precisely what Tang does.
 
 ##### Installation
 
+    $ autoreconf -fi
     $ ./configure
     $ make
     $ sudo make install


### PR DESCRIPTION
This, or at least some version of autoconf, is necessary since './configure' does not exist by default.