### PR TITLE
tests: support /lib/systemd/systemd-activate

### DIFF
--- a/tests/adv
+++ b/tests/adv
@@ -28,8 +28,12 @@ trap 'exit' ERR
 
 if SD_ACTIVATE=`which systemd-socket-activate`; then
   INET=--inet
+elif SD_ACTIVATE=`which /usr/lib/systemd/systemd-activate`; then
+  :
+elif SD_ACTIVATE=`which /lib/systemd/systemd-activate`; then
+  :
 else
-  SD_ACTIVATE=/usr/lib/systemd/systemd-activate
+  exit 1
 fi
 
 export TMP=`mktemp -d`

--- a/tests/rec
+++ b/tests/rec
@@ -28,8 +28,12 @@ trap 'exit' ERR
 
 if SD_ACTIVATE=`which systemd-socket-activate`; then
   INET=--inet
+elif SD_ACTIVATE=`which /usr/lib/systemd/systemd-activate`; then
+  :
+elif SD_ACTIVATE=`which /lib/systemd/systemd-activate`; then
+  :
 else
-  SD_ACTIVATE=/usr/lib/systemd/systemd-activate
+  exit 1
 fi
 
 export TMP=`mktemp -d`


### PR DESCRIPTION
When /usr/lib/systemd/systemd-activate does not exist but
/lib/systemd/systemd-activate does.

Signed-off-by: Loic Dachary <loic@dachary.org>