### PR TITLE
Let world know how lightweight Tang really is

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ packages:
 3. jose - ``jose``, ``libjose-devel``
 4. curl - curl (only needed for running tests)
 
+#### OpenWrt
+
+Tang is also capable of running on devices without systemd even for example OpenWrt
+(see: [this PR](https://github.com/openwrt/packages/pull/5447)).
+Instead of using systemd for socket activation you can use another daemon for spawning services like xinetd.
+Without systemd watching Tang's database directory you will have to make sure that key cache is generated properly.
+
+An example of configuration file for Tang using xinetd can be found in the `units/` directory.
+
 ### Building and Installing from Source
 
 Building Tang is fairly straightforward:

--- a/units/tangd.xinetd
+++ b/units/tangd.xinetd
@@ -1,0 +1,10 @@
+service tangd
+{
+    port = 80
+    server_args = /var/cache/tang
+    server = /usr/libexec/tangd
+    socket_type = stream
+    protocol = tcp
+    user = root
+    wait = no
+}


### PR DESCRIPTION
Add an example configuration file for xinetd daemon.
Alter README.md to highlight that Tang can be run on
small devices such as Wi-Fi routers running Openwrt
using xinetd for socket activation.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>