### PR TITLE
Fix dockerfile link

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ An example of configuration file for Tang using xinetd can be found in the
 #### Docker Container
 
 Tang is also available as a [Docker
-Container](https://github.com/AdrianKoshka/tang-docker-container/).
+Container](https://gitlab.com/AdrianKoshka/tang-docker-container/).
 
 Care should be taken to ensure that, when deploying in a container cluster,
 that the Tang keys are not stored on the same physical medium that you wish to


### PR DESCRIPTION
The dockerfile seems to have moved from github to gitlab. I don't know the old Dockerfile, but it is the same user, so probably it is the same repository.