### PR TITLE
Use -Wformat in addition to -Wformat-security in add_project_arguments

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -30,6 +30,7 @@ add_project_arguments(
   '-D_POSIX_C_SOURCE=200809L',
   '-Wstrict-aliasing',
   '-Wchar-subscripts',
+  '-Wformat',
   '-Wformat-security',
   '-Wmissing-declarations',
   '-Wmissing-prototypes',


### PR DESCRIPTION
When using `meson --buildtype=plain` (e.g. for packaging), compilation fails with
```
cc1: error: ‘-Wformat-security’ ignored without ‘-Wformat’ [-Werror=format-security]
cc1: all warnings being treated as errors
```
Add `-Wformat` to make `-Wformat-security` work even when not using the default meson warning configuration.