### PR TITLE
Fixed Ordering cycle found, causing spurious issues during boot (no tangd.socket enabled, or no network, etc.)

### DIFF
--- a/units/tangd.socket
+++ b/units/tangd.socket
@@ -1,14 +1,9 @@
 [Unit]
 Description=Tang Server socket
-Requires=tangd-keygen.service
-Requires=tangd-update.service
-Requires=tangd-update.path
-After=tangd-keygen.service
-After=tangd-update.service
 
 [Socket]
 ListenStream=80
 Accept=true
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sockets.target

--- a/units/tangd@.service.in
+++ b/units/tangd@.service.in
@@ -1,5 +1,7 @@
 [Unit]
 Description=Tang Server
+Requires=tangd-keygen.service
+After=tangd-keygen.service
 
 [Service]
 StandardInput=socket


### PR DESCRIPTION
This commit fixes the following ordering cycle found on Fedora 30+ and RHEL 8.1:

~~~
systemd[1]: sockets.target: Found ordering cycle on tangd.socket/start
systemd[1]: sockets.target: Found dependency on tangd-keygen.service/start
systemd[1]: sockets.target: Found dependency on basic.target/start
systemd[1]: sockets.target: Found dependency on sockets.target/start
systemd[1]: sockets.target: Job tangd.socket/start deleted to break ordering cycle starting with sockets.target/start
[ SKIP ] Ordering cycle found, skipping Tang Server socket
~~~

This is tracked by Red Hat through [BZ #1792173](https://bugzilla.redhat.com/show_bug.cgi?id=1792173)

The previous implementation of the Tang socket was making it depend on services, which is not how sockets are expected to be configured.
Additionally, the Tang socket was installed in `multi-user.target` instead of `sockets.target`.

This implementation creates a _standard_ socket installed in `sockets.target`, and modifies the corresponding service so that it makes sure the requirement on the key presence is met.
The requirement on `tangd-update.service` has been removed since it is useless: the service doesn't need `tangd-update.service` at all.