### PR TITLE
Added support for power (leppc64) platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ services:
 compiler:
   - gcc
 
+arch:
+  - ppc64le
+
 env:
   - DISTRO=fedora:latest
   - DISTRO=centos:7


### PR DESCRIPTION
Hi,
I had added ppc64le (Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

  https://travis-ci.com/github/ujjwalsh/tang/builds/182291915 .

Please have a look.

Regards,
ujjwal