### PR TITLE
Exit with success unless the issue was with with tangd itself

### DIFF
--- a/src/tangd.c
+++ b/src/tangd.c
@@ -205,7 +205,7 @@ main(int argc, char *argv[])
         if (parser.http_errno != 0) {
             fprintf(stderr, "HTTP Parsing Error: %s\n",
                     http_errno_description(parser.http_errno));
-            return EXIT_FAILURE;
+            return EXIT_SUCCESS;
         }
 
         memmove(req, &req[r], rcvd - r);


### PR DESCRIPTION
When an HTTP parser error happens, tangd is currently exiting with an
error status, which may cause trouble in some scenarios [1].

However, we don't exit with an error in situations where we try requests
that do not exist, for instance. It makes sense to only exit with an
error when the error was with tangd itself, e.g.: when we are unable to
read the directory with the keys, not when the actual HTTP operation
does not succeed for some reason.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1828558