### PR TITLE
tang-show-keys and tangd-keygen now use SHA-256 for the thumbprints

### DIFF
--- a/src/tang-show-keys
+++ b/src/tang-show-keys
@@ -29,7 +29,8 @@ port=${1-80}
 
 adv=$(curl -sSf localhost:$port/adv)
 
+THP_DEFAULT_HASH=S256    # SHA-256.
 echo $adv \
     | jose fmt -j- -g payload -y -o- \
     | jose jwk use -i- -r -u verify -o- \
-    | jose jwk thp -i-
+    | jose jwk thp -i- -a "${THP_DEFAULT_HASH}"

--- a/src/tangd-keygen
+++ b/src/tangd-keygen
@@ -27,10 +27,11 @@ fi
 
 [ $# -eq 3 ] && sig=$2 && exc=$3
 
+THP_DEFAULT_HASH=S256     # SHA-256.
 jwe=`jose jwk gen -i '{"alg":"ES512"}'`
-[ -z "$sig" ] && sig=`echo "$jwe" | jose jwk thp -i-`
+[ -z "$sig" ] && sig=$(echo "$jwe" | jose jwk thp -i- -a "${THP_DEFAULT_HASH}")
 echo "$jwe" > $1/$sig.jwk
 
 jwe=`jose jwk gen -i '{"alg":"ECMR"}'`
-[ -z "$exc" ] && exc=`echo "$jwe" | jose jwk thp -i-`
+[ -z "$exc" ] && exc=$(echo "$jwe" | jose jwk thp -i- -a "${THP_DEFAULT_HASH}")
 echo "$jwe" > $1/$exc.jwk

--- a/tests/adv
+++ b/tests/adv
@@ -82,4 +82,5 @@ fetch /adv/`jose jwk thp -i $TMP/db/.sig.jwk` \
                -g 0 -Og protected -SyOg cty -Sq "jwk-set+json" -EUUUUU \
                -g 1 -Og protected -SyOg cty -Sq "jwk-set+json" -EUUUUU
 
-test "$(tang-show-keys $PORT)" == "$(jose jwk thp -i $TMP/db/sig.jwk)"
+THP_DEFAULT_HASH=S256     # SHA-256.
+test "$(tang-show-keys $PORT)" == "$(jose jwk thp -a "${THP_DEFAULT_HASH}" -i $TMP/db/sig.jwk)"


### PR DESCRIPTION
From release 18, clevis changed to use SHA-256 as the default hash for
the JWK thumbprints. Let's update tang-show-keys and tangd-keygen to
also do that.