### PR TITLE
Add tangd-rotate-keys helper script

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -9,5 +9,6 @@ tangd = executable('tangd',
 
 bins += join_paths(meson.current_source_dir(), 'tang-show-keys')
 libexecbins += join_paths(meson.current_source_dir(), 'tangd-keygen')
+libexecbins += join_paths(meson.current_source_dir(), 'tangd-rotate-keys')
 
 # vim:set ts=2 sw=2 et:

--- a/src/tangd-rotate-keys
+++ b/src/tangd-rotate-keys
@@ -1,0 +1,85 @@
+#!/bin/sh -e
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+SUMMARY="Perform rotation of tang keys"
+
+usage() {
+    local _ret="${1:-1}"
+    exec >&2
+    echo "Usage: ${0} [-h] [-v] -d <KEYDIR>"
+    echo
+    echo "${SUMMARY}"
+    echo
+    echo "  -d KEYDIR  The directory with the keys, e.g. /var/db/tang"
+    echo
+    echo "  -h         Display this usage information"
+    echo
+    echo "  -v         Verbose. Display additional info on keys created/rotated"
+    echo
+    exit "${_ret}"
+}
+
+log() {
+    local _msg="${1}"
+    local _verbose="${2:-}"
+    [ -z "${_verbose}" ] && return 0
+    echo "${_msg}" >&2
+}
+
+error() {
+    log "${1}" 1
+    usage 1
+}
+
+JWKDIR=
+VERBOSE=
+while getopts "hvd:" o; do
+    case "${o}" in
+        d) JWKDIR="${OPTARG}";;
+        h) usage 0;;
+        v) VERBOSE=1;;
+        *) usage 1;;
+    esac
+done
+
+[ -z "${JWKDIR}" ] && error "Please specify the keys directory with -d switch"
+[ -r "${JWKDIR}" ] || error "Error trying to access JWK directory '${JWKDIR}'"
+
+cd "${JWKDIR}" || error "Unable to change to keys directory '${JWKDIR}'"
+    # Disable advertisement of current keys.
+    for key in *.jwk; do
+        [ -r "${key}" ] || continue
+        mv -f -- "${key}" ."${key}"
+        log "Disabled advertisement of key ${key} -> .${key}" "${VERBOSE}"
+    done
+
+    # Create a new set of keys.
+    DEFAULT_THP_HASH="S256"
+    for alg in "ES512" "ECMR"; do
+        json="$(printf '{"alg": "%s"}' "${alg}")"
+        jwe="$(jose jwk gen --input "${json}")"
+        thp="$(printf '%s' "${jwe}" | jose jwk thp --input=- \
+                                           -a "${DEFAULT_THP_HASH}")"
+        echo "${jwe}" > "${thp}.jwk"
+        log "Created new key ${thp}.jwk" "${VERBOSE}"
+    done
+cd - >/dev/null
+
+log "Keys rotated successfully" "${VERBOSE}"


### PR DESCRIPTION
So that it becomes simpler to perform key rotation on the server side.

Usage: tangd-rotate-keys [-h] [-v] -d <KEYDIR>

Example:

$ sudo tangd-rotate-keys -d /var/db/tang -v
Disabled advertisement of key 5AiUA4IhvOFdXzFavO78TKJ8hEsfGk8I6ymy4rBPWi8.jwk -> .5AiUA4IhvOFdXzFavO78TKJ8hEsfGk8I6ymy4rBPWi8.jwk
Disabled advertisement of key dDC74X-o31Fq5VJaM9iZ4baZD2hhHw-RrIMkxEz35Xc.jwk -> .dDC74X-o31Fq5VJaM9iZ4baZD2hhHw-RrIMkxEz35Xc.jwk
Created new key bIGVyIP2D_NJGQeFA9cf9oix5KEVQyVq9ZGjjv0s3D8.jwk
Created new key BL4IR73UhG8yyYbvGJspPIlLvG6AzTnM850tlCKrcII.jwk
Keys rotated successfully