### PR TITLE
meson: remove pointless dirs parameter

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -54,7 +54,7 @@ compiler = meson.get_compiler('c')
 if not compiler.has_header('http_parser.h',args : '-I/usr/local/include')
   error('http-parser devel files not found.')
 endif
-http_parser = compiler.find_library('http_parser',dirs:['/usr/lib','/usr/local/lib'])
+http_parser = compiler.find_library('http_parser')
 
 licenses = ['COPYING']
 libexecbins = []


### PR DESCRIPTION
This breaks cross compilation. It's also wrong. Setting PKG_CONFIG_PATH properly
allows meson to find it.