### PR TITLE
Clean up some FreeBSD conditions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,7 @@ sysconfdir = join_paths(get_option('prefix'), get_option('sysconfdir'))
 bindir = join_paths(get_option('prefix'), get_option('bindir'))
 systemunitdir = join_paths(get_option('prefix'), 'lib/systemd/system')
 licensedir = join_paths(get_option('prefix'), 'share', 'licenses', meson.project_name())
-if build_machine.system() == 'freebsd'
+if host_machine.system() == 'freebsd'
   licensedir += '-'+meson.project_version()
 endif
 jwkdir = join_paths(get_option('localstatedir'), 'db', meson.project_name())
@@ -54,7 +54,11 @@ compiler = meson.get_compiler('c')
 if not compiler.has_header('http_parser.h',args : '-I/usr/local/include')
   error('http-parser devel files not found.')
 endif
-http_parser = compiler.find_library('http_parser',dirs:['/usr/lib','/usr/local/lib'])
+if host_machine.system() == 'freebsd'
+  http_parser = compiler.find_library('http_parser',dirs : '/usr/local/lib')
+else
+  http_parser = compiler.find_library('http_parser')
+endif
 
 licenses = ['COPYING']
 libexecbins = []

--- a/units/meson.build
+++ b/units/meson.build
@@ -3,7 +3,7 @@ tangd_service = configure_file(
   output: 'tangd@.service',
   configuration: data
 )
-if build_machine.system() == 'freebsd'
+if host_machine.system() == 'freebsd'
   tangd_rc = configure_file(
     input: 'tangd.rc.in',
     output: 'tangd',


### PR DESCRIPTION
Relatively small changes to check for host_machine vs. build_machine as the target to account for possible cross compilation.  Also adjusts the way the http-parser library is found to leave the default a more standard method in response to problems with the complex cross compilation scripts of openwrt raised in PR #72 