### PR TITLE
Specify user and group for tang

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,6 +26,8 @@ data.set('libexecdir', libexecdir)
 data.set('sysconfdir', sysconfdir)
 data.set('systemunitdir', systemunitdir)
 data.set('jwkdir', jwkdir)
+data.set('user', get_option('user'))
+data.set('group', get_option('group'))
 
 add_project_arguments(
   '-D_POSIX_C_SOURCE=200809L',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('user', type: 'string', value: 'tang', description: 'Unprivileged user for tang operations')
+option('group', type: 'string', value: 'tang', description: 'Unprivileged group for tang operations')

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,8 +7,22 @@ tangd = executable('tangd',
   install_dir: libexecdir
 )
 
+tangd_keygen = configure_file(
+  input: 'tangd-keygen.in',
+  output: 'tangd-keygen',
+  configuration: data,
+  install: true,
+  install_dir: libexecdir
+)
+
+tangd_rotate_keys = configure_file(
+  input: 'tangd-rotate-keys.in',
+  output: 'tangd-rotate-keys',
+  configuration: data,
+  install: true,
+  install_dir: libexecdir
+)
+
 bins += join_paths(meson.current_source_dir(), 'tang-show-keys')
-libexecbins += join_paths(meson.current_source_dir(), 'tangd-keygen')
-libexecbins += join_paths(meson.current_source_dir(), 'tangd-rotate-keys')
 
 # vim:set ts=2 sw=2 et:

--- a/src/tangd-keygen.in
+++ b/src/tangd-keygen.in
@@ -25,6 +25,13 @@ usage() {
     exit 1
 }
 
+set_perms() {
+    chmod 0440 -- "${1}"
+    if ! chown @user@:@group@ -- "${1}" 2>/dev/null; then
+        echo "Unable to change owner/group for ${1} to @user@:@group@" >&2
+    fi
+}
+
 [ $# -ne 1 ] && [ $# -ne 3 ] && usage
 [ -d "$1" ] || usage
 
@@ -34,10 +41,10 @@ THP_DEFAULT_HASH=S256     # SHA-256.
 jwe=$(jose jwk gen -i '{"alg":"ES512"}')
 [ -z "$sig" ] && sig=$(echo "$jwe" | jose jwk thp -i- -a "${THP_DEFAULT_HASH}")
 echo "$jwe" > "$1/$sig.jwk"
-chmod 0440 "$1/$sig.jwk"
+set_perms "$1/$sig.jwk"
 
 
 jwe=$(jose jwk gen -i '{"alg":"ECMR"}')
 [ -z "$exc" ] && exc=$(echo "$jwe" | jose jwk thp -i- -a "${THP_DEFAULT_HASH}")
 echo "$jwe" > "$1/$exc.jwk"
-chmod 0440 "$1/$exc.jwk"
+set_perms "$1/$exc.jwk"

--- a/src/tangd-rotate-keys.in
+++ b/src/tangd-rotate-keys.in
@@ -48,6 +48,13 @@ error() {
     usage 1
 }
 
+set_perms() {
+    chmod 0440 -- "${1}"
+    if ! chown @user@:@group@ -- "${1}" 2>/dev/null; then
+        echo "Unable to change owner/group for ${1} to @user@:@group@" >&2
+    fi
+}
+
 JWKDIR=
 VERBOSE=
 while getopts "hvd:" o; do
@@ -78,7 +85,7 @@ cd "${JWKDIR}" || error "Unable to change to keys directory '${JWKDIR}'"
         thp="$(printf '%s' "${jwe}" | jose jwk thp --input=- \
                                            -a "${DEFAULT_THP_HASH}")"
         echo "${jwe}" > "${thp}.jwk"
-        chmod 0440 "${thp}.jwk"
+        set_perms "${thp}.jwk"
         log "Created new key ${thp}.jwk" "${VERBOSE}"
     done
 cd - >/dev/null

--- a/units/tangd@.service.in
+++ b/units/tangd@.service.in
@@ -6,3 +6,4 @@ StandardInput=socket
 StandardOutput=socket
 StandardError=journal
 ExecStart=@libexecdir@/tangd @jwkdir@
+User=@user@


### PR DESCRIPTION
So that we can run tang itself with a different user.

Systemd unit and helpers for rotating keys updated to use the
new user and group.