### PR TITLE
Fix github action CI by setting appropriate centos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,8 @@ jobs:
       matrix:
         os:
           - fedora:latest
-          - centos:7
-          - centos:8
+          - quay.io/centos/centos:stream8
+          - quay.io/centos/centos:stream9          
           - debian:testing
           - debian:latest
           - ubuntu:rolling

--- a/.github/workflows/install-dependencies
+++ b/.github/workflows/install-dependencies
@@ -17,11 +17,11 @@ fedora:*)
                    systemd gcovr curl socat
     ;;
 
-centos:*)
+*centos:*)
     yum -y clean all
     yum -y --setopt=deltarpm=0 update
     yum install -y yum-utils epel-release
-    yum config-manager -y --set-enabled PowerTools \
+    yum config-manager -y --set-enabled crb \
         || yum config-manager -y --set-enabled powertools || :
     yum -y install meson socat
     yum-builddep -y tang


### PR DESCRIPTION
This change fixes centos8 container repository,
removes centos7 and includes centos9 as additional stage

Signed-off-by: Sergio Arroutbi <sarroutb@redhat.com>