### PR TITLE
tangd.socket: Set ownership and mode of jwkdir

### DIFF
--- a/units/meson.build
+++ b/units/meson.build
@@ -3,6 +3,11 @@ tangd_service = configure_file(
   output: 'tangd@.service',
   configuration: data
 )
+tangd_socket = configure_file(
+  input: 'tangd.socket.in',
+  output: 'tangd.socket',
+  configuration: data
+)
 if host_machine.system() == 'freebsd'
   tangd_rc = configure_file(
     input: 'tangd.rc.in',
@@ -12,7 +17,7 @@ if host_machine.system() == 'freebsd'
     install_mode: ['rwxr-xr-x', 'root', 'wheel']
   )
 else
-  units += join_paths(meson.current_source_dir(), 'tangd.socket')
+  units += tangd_socket
   units += tangd_service
 endif
 

--- a/units/tangd.socket.in
+++ b/units/tangd.socket.in
@@ -6,5 +6,8 @@ Documentation=man:tang(8)
 ListenStream=80
 Accept=true
 
+ExecStartPre=-/usr/bin/chmod --silent 0440 -- @jwkdir@/*.jwk @jwkdir@/.*.jwk
+ExecStartPre=-/usr/bin/chown -R @user@:@group@ @jwkdir@
+
 [Install]
 WantedBy=sockets.target


### PR DESCRIPTION
On OSTree-enabled systems (such as Fedora CoreOS), every update recreates the passwd and group files, which means that the dynamically-assigned ID and GID of the tang daemon may change, depending on the order of createuser calls. This patch ensures that starting the socket unit will fix any ownership issues in the jwkdir.

This is essentially moving the [Fedora %post script](https://src.fedoraproject.org/rpms/tang/blob/ba7119863624a55ac4bf79e19acd2a26350896e0/f/tang.spec#_68) out of RPM and into the systemd unit instead.