### PR TITLE
Fix race condition when creating/rotating keys

### DIFF
--- a/src/keys.c
+++ b/src/keys.c
@@ -307,6 +307,9 @@ create_new_keys(const char* jwkdir)
 {
     const char* alg[] = {"ES512", "ECMR", NULL};
     char path[PATH_MAX];
+
+    /* Set default umask for file creation. */
+    umask(0337);
     for (int i = 0; alg[i] != NULL; i++) {
         json_auto_t* jwk = jwk_generate(alg[i]);
         if (!jwk) {

--- a/src/tangd-keygen.in
+++ b/src/tangd-keygen.in
@@ -38,6 +38,10 @@ set_perms() {
 [ $# -eq 3 ] && sig=$2 && exc=$3
 
 THP_DEFAULT_HASH=S256     # SHA-256.
+
+# Set default umask for file creation.
+umask 0337
+
 jwe=$(jose jwk gen -i '{"alg":"ES512"}')
 [ -z "$sig" ] && sig=$(echo "$jwe" | jose jwk thp -i- -a "${THP_DEFAULT_HASH}")
 echo "$jwe" > "$1/$sig.jwk"

--- a/src/tangd-rotate-keys.in
+++ b/src/tangd-rotate-keys.in
@@ -79,6 +79,10 @@ cd "${JWKDIR}" || error "Unable to change to keys directory '${JWKDIR}'"
 
     # Create a new set of keys.
     DEFAULT_THP_HASH="S256"
+
+    # Set default umask for file creation.
+    umask 0337
+
     for alg in "ES512" "ECMR"; do
         json="$(printf '{"alg": "%s"}' "${alg}")"
         jwe="$(jose jwk gen --input "${json}")"


### PR DESCRIPTION
When we create/rotate keys using either the tangd-keygen and tangd-rotate-keys helpers, there is a small window between the keys being created and then the proper ownership permissions being set. This also happens when there are no keys and tang creates a pair of keys itself.

In certain situations, such as the keys directory having wide open permissions, a user with local access could exploit this race condition and read the keys before they are set to more restrictive permissions.

To prevent this issue, we now set the default umask to 0337 before creating the files, so that they are already created with restrictive permissions; afterwards, we set the proper ownership as usual.

Issue reported by Brian McDermott of CENSUS labs.

Fixes CVE-2023-1672


Reviewed-by: Sergio Arroutbi <sarroutb@redhat.com>