### PR TITLE
Add support for building with llhttp instead of http-parser

### DIFF
--- a/.github/workflows/install-dependencies
+++ b/.github/workflows/install-dependencies
@@ -13,7 +13,7 @@ debian:*|ubuntu:*)
     echo 'max_parallel_downloads=10' >> /etc/dnf/dnf.conf
     dnf -y clean all
     dnf -y --setopt=deltarpm=0 update
-    dnf -y install gcc meson pkgconfig libjose-devel jose http-parser-devel \
+    dnf -y install gcc meson pkgconfig libjose-devel jose llhttp-devel \
                    systemd gcovr curl socat iproute
     ;;
 

--- a/meson.build
+++ b/meson.build
@@ -55,13 +55,22 @@ add_project_arguments('-DVERSION="'+meson.project_version() + '"', language : 'c
 jose = dependency('jose', version: '>=8')
 a2x = find_program('a2x', required: false)
 compiler = meson.get_compiler('c')
-if not compiler.has_header('http_parser.h',args : '-I/usr/local/include')
-  error('http-parser devel files not found.')
-endif
-if host_machine.system() == 'freebsd'
-  http_parser = compiler.find_library('http_parser',dirs : '/usr/local/lib')
+
+http_lib = []
+if compiler.has_header('llhttp.h', args: '-I/usr/local/include')
+  http_lib = 'llhttp'
+  add_project_arguments('-DUSE_LLHTTP', language: 'c')
 else
-  http_parser = compiler.find_library('http_parser')
+  if not compiler.has_header('http_parser.h', args: '-I/usr/local/include')
+    error('neither llhttp nor http-parser devel files found.')
+  endif
+  http_lib = 'http_parser'
+endif
+
+if host_machine.system() == 'freebsd'
+  http_parser = compiler.find_library(http_lib, dirs : '/usr/local/lib')
+else
+  http_parser = compiler.find_library(http_lib)
 endif
 
 licenses = ['COPYING']

--- a/src/http.c
+++ b/src/http.c
@@ -36,7 +36,7 @@ HTTP_METHOD_MAP(XX)
 };
 
 static int
-on_url(http_parser *parser, const char *at, size_t length)
+on_url(http_parser_t *parser, const char *at, size_t length)
 {
     struct http_state *state = parser->data;
 
@@ -51,7 +51,7 @@ on_url(http_parser *parser, const char *at, size_t length)
 }
 
 static int
-on_body(http_parser *parser, const char *at, size_t length)
+on_body(http_parser_t *parser, const char *at, size_t length)
 {
     struct http_state *state = parser->data;
 
@@ -66,7 +66,7 @@ on_body(http_parser *parser, const char *at, size_t length)
 }
 
 static int
-on_message_complete(http_parser *parser)
+on_message_complete(http_parser_t *parser)
 {
     struct http_state *state = parser->data;
     const char *addr = NULL;
@@ -132,7 +132,7 @@ egress:
     return 0;
 }
 
-const http_parser_settings http_settings = {
+const http_settings_t http_settings = {
     .on_url = on_url,
     .on_body = on_body,
     .on_message_complete = on_message_complete,
@@ -140,7 +140,7 @@ const http_parser_settings http_settings = {
 
 int
 http_reply(const char *file, int line,
-           enum http_status code, const char *fmt, ...)
+           http_status_t code, const char *fmt, ...)
 {
     const char *msg = NULL;
     va_list ap;


### PR DESCRIPTION
As http-parser has been unmaintained for a while [1], let's add support for its natural replacement, llhttp.

However, as llhttp does not seem to be packaged in distros like Debian [2], we will keep supporting building with http-parser for time being, preferring llhttp, if it is present.

Resolves: #64 

[1] https://github.com/nodejs/http-parser/issues/522
[2] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=977716