### PR TITLE
Upgrade checkout Github action (v3->v4)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,16 +17,15 @@ jobs:
       matrix:
         os:
           - fedora:latest
-          - centos:7
           - quay.io/centos/centos:stream8
           - quay.io/centos/centos:stream9
           - debian:testing
           - debian:latest
+          - ubuntu:latest
           - ubuntu:rolling
           - ubuntu:lunar
           - ubuntu:jammy
           - ubuntu:focal
-          - ubuntu:bionic
         stable: [true]
         include:
           - os: quay.io/fedora/fedora:rawhide
@@ -34,7 +33,7 @@ jobs:
           - os: ubuntu:devel
             stable: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Show OS information
         run: cat /etc/os-release 2>/dev/null || \

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ jobs:
         os:
           - ubuntu:latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Show OS information
         run: cat /etc/os-release 2>/dev/null || echo /etc/os-release not available


### PR DESCRIPTION
Updating to Node20 involves removal of a pair of distributions for compilation:
- Ubuntu Bionic (End of Life Date was 31 May 2023)
- Centos7 (End of Life Date for 30 Jun 2024)

Resolves: #141