### PR TITLE
Cirrus CI for FreeBSD builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,15 @@
+task:
+  skip: "changesIncludeOnly('**.md','.github/workflows/**')"
+  freebsd_instance:
+    matrix:
+      - image_family: freebsd-13-2
+      - image_family: freebsd-14-0
+      - image_family: freebsd-15-0-snap
+
+  install_script: pkg install -y jose git meson pkgconf jansson asciidoc llhttp socat
+
+  script:
+    - mkdir build && cd build
+    - meson setup .. --prefix=/usr/local
+    - ninja
+    - meson test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,11 @@ on:
   push:
     paths-ignore:
       - '**.md'
+      - '.cirrus.yml'
   pull_request:
     paths-ignore:
       - '**.md'
+      - '.cirrus.yml'
 
 jobs:
   build:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,9 +5,11 @@ on:
   push:
     paths-ignore:
       - '**.md'
+      - '.cirrus.yml'
   pull_request:
     paths-ignore:
       - '**.md'
+      - '.cirrus.yml'
 
 jobs:
   build:


### PR DESCRIPTION
I don't know if there is any interest in this. It seems that GitHub has no interest in supporting FreeBSD runners, but Cirrus CI does.  It requires a (free for open source) Cirrus CI account and installing the CirrusCI  application for the repository.  This PR is for the config file to run FreeBSD tests (and for github actions to ignore changes to the config since it won't affect the GitHub actions.)