### PR TITLE
Fix memory leak reported by clang tool

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -201,6 +201,9 @@ int run_service(const char *jwkdir, int port, process_request_func pfunc)
 	r = listen_port(&slist, port);
 	if (r < 0) {
 		fprintf(stderr, "Could not listen port (%d)\n", port);
+		if (slist) {
+			free_socket_list(slist);
+		}
 		return -1;
 	}
 


### PR DESCRIPTION
This memory leak, although not easily reproducible, has been detected by Static Application Security Testing tool. This fix eliminates it.